### PR TITLE
Update and revise template inspired by Rust

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,3 +1,4 @@
+- Feature Name: (fill me in with a unique ident, my_awesome_feature)
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: (leave this empty)
 - Bundler Issue: (leave this empty)
@@ -8,41 +9,44 @@ One paragraph explanation of the feature.
 
 # Motivation
 
-Why are we doing this? What use cases does it support? What is the expected
-outcome?
+Why are we doing this? What use cases does it support? What is the expected outcome?
 
-# Detailed design
+# Guide-level explanation
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody
-familiar with the tool to understand, and for somebody familiar with the
-implementation to implement. This should get into specifics and corner-cases,
-and include examples of how the feature is used. Any new terminology should be
-defined here.
+Explain the proposal as if it was already implemented and released, and you were teaching it to another developer. That generally means:
 
-# How We Teach This
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how users should *think* about the feature, and how it should impact the way they use Bundler. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing user and new users.
 
-What names and terminology work best for these concepts and why? How is this
-idea best presented? As a continuation of existing Bundler patterns, or as a
-wholly new one?
+For implementation-oriented RFCs, this section should focus on how contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 
-Would the acceptance of this proposal mean the Bundler documentation will need
-to be re-organized or altered? Does it change how new users are taught to
-manage dependencies? How should this change be introduced and taught to
-existing users?
+# Reference-level explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
 
 # Drawbacks
 
-Why should we *not* do this? Please consider the impact on existing users, on
-the documentation, on the integration of this feature with other existing and
-planned features, on the impact on existing apps, etc.
+Why should we *not* do this? Please consider the impact on existing users, on the documentation, on the integration of this feature with other existing and planned features, on the impact on existing apps, etc.
 
 There are tradeoffs to choosing any path, please attempt to identify them here.
 
-# Alternatives
+# Rationale and Alternatives
 
-What other designs have been considered? What is the impact of not doing this?
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
 
 # Unresolved questions
 
-Optional, but suggested for first drafts. What parts of the design are still
-TBD?
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before it is on by default?
+- What related issues do you consider out of scope for this RFC tha could be addressed in the future independently of the solution that comes out of this RFC?

--- a/0000-template.md
+++ b/0000-template.md
@@ -1,4 +1,4 @@
-- Feature Name: (fill me in with a unique ident, my_awesome_feature)
+- Feature Name: (fill me in with a unique ident, my\_awesome\_feature)
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: (leave this empty)
 - Bundler Issue: (leave this empty)
@@ -19,7 +19,7 @@ Explain the proposal as if it was already implemented and released, and you were
 - Explaining the feature largely in terms of examples.
 - Explaining how users should *think* about the feature, and how it should impact the way they use Bundler. It should explain the impact as concretely as possible.
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing user and new users.
+- If applicable, describe the differences between teaching this to existing users and new users.
 
 For implementation-oriented RFCs, this section should focus on how contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 
@@ -49,4 +49,4 @@ There are tradeoffs to choosing any path, please attempt to identify them here.
 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?
 - What parts of the design do you expect to resolve through the implementation of this feature before it is on by default?
-- What related issues do you consider out of scope for this RFC tha could be addressed in the future independently of the solution that comes out of this RFC?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?


### PR DESCRIPTION
The Rust RFC template has recently been revised to emphasize describing the proposal in terms of documentation for the thing being proposed. I think that's a really, really good idea, so I borrowed liberally from the newest Rust RFC template to revise and expand our template.